### PR TITLE
chore: chapter-01-04 增加 rollup-plugin-delete 插件

### DIFF
--- a/demo/chapter-01-04/.gitignore
+++ b/demo/chapter-01-04/.gitignore
@@ -58,3 +58,5 @@ typings/
 .env
 
 dist/
+
+yarn.lock

--- a/demo/chapter-01-04/build/rollup.config.js
+++ b/demo/chapter-01-04/build/rollup.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const { babel } = require('@rollup/plugin-babel');
+const del = require('rollup-plugin-delete');
 
 const resolveFile = function(filePath) {
   return path.join(__dirname, '..', filePath)
@@ -13,6 +14,7 @@ module.exports = {
     sourcemap: true,
   }, 
   plugins: [
+    del({ targets: 'dist/*' }),
     babel({
       presets: ['@babel/preset-env']
     }),

--- a/demo/chapter-01-04/package.json
+++ b/demo/chapter-01-04/package.json
@@ -14,6 +14,7 @@
     "@babel/preset-env": "^7.9.6",
     "@rollup/plugin-babel": "^5.0.0",
     "rollup": "^2.7.6",
+    "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-serve": "^1.0.1",
     "rollup-plugin-uglify": "^6.0.4"
   },

--- a/note/chapter01/04.md
+++ b/note/chapter01/04.md
@@ -68,6 +68,9 @@ npm i --save-dev rollup-plugin-serve
 
 ## 安装 rollup.js 编译代码混淆插件
 npm i --save-dev rollup-plugin-uglify
+
+## 安装 rollup-plugin-delete 删除指定目录
+npm i --save-dev rollup-plugin-delete
 ```
 
 
@@ -80,6 +83,7 @@ npm i --save-dev rollup-plugin-uglify
 ```js
 const path = require('path');
 const { babel } = require('@rollup/plugin-babel');
+const del = require('rollup-plugin-delete');
 
 const resolveFile = function(filePath) {
   return path.join(__dirname, '..', filePath)
@@ -93,6 +97,7 @@ module.exports = {
     sourcemap: true,
   }, 
   plugins: [
+    del({ targets: 'dist/*' }),
     babel({
       presets: ['@babel/preset-env']
     }),


### PR DESCRIPTION
`chapter-01-04` 中存在两种模式（开发/生产），在生成的目录中需要先将 dist 目录清空以后再进行打包构建。